### PR TITLE
feat: implement internal add support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,34 +35,34 @@ jobs:
         run: yarn test:unit
         env:
           TS_NODE_SKIP_IGNORE: true
-  # e2e:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out github repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 1
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out github repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
-  #     - name: Cache node modules
-  #       uses: actions/cache@v2
-  #       env:
-  #         cache-name: cache-node-modules
-  #       with:
-  #         path: "**/node_modules"
-  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: "16.x"
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
 
-  #     - name: Install dependencies
-  #       run: yarn --frozen-lockfile
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
 
-  #     - name: Run e2e tests
-  #       run: yarn test:e2e
-  #       env:
-  #         TS_NODE_SKIP_IGNORE: true
+      - name: Run e2e tests
+        run: yarn test:e2e
+        env:
+          TS_NODE_SKIP_IGNORE: true
   # integration:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/solidity/contracts/OracleAggregator.sol
+++ b/solidity/contracts/OracleAggregator.sol
@@ -11,7 +11,7 @@ contract OracleAggregator is AccessControl, IOracleAggregator {
 
   // A list of available oracles. Oracles first on the array will take precedence over those that come later
   IPriceOracle[] internal _availableOracles;
-  mapping(bytes32 => IPriceOracle) internal _assignedOracle; // key(tokenA, tokenB) => oracle
+  mapping(bytes32 => OracleAssignment) internal _assignedOracle; // key(tokenA, tokenB) => oracle
 
   constructor(
     IPriceOracle[] memory _initialOracles,
@@ -45,19 +45,65 @@ contract OracleAggregator is AccessControl, IOracleAggregator {
   }
 
   /// @inheritdoc IPriceOracle
+  function isPairAlreadySupported(address _tokenA, address _tokenB) public view returns (bool) {
+    IPriceOracle _oracle = assignedOracle(_tokenA, _tokenB).oracle;
+    // We check if the oracle still supports the pair, since it might have lost support
+    return address(_oracle) != address(0) && _oracle.isPairAlreadySupported(_tokenA, _tokenA);
+  }
+
+  /// @inheritdoc IPriceOracle
+  function quote(
+    address _tokenIn,
+    uint256 _amountIn,
+    address _tokenOut
+  ) external view returns (uint256 _amountOut) {
+    IPriceOracle _oracle = assignedOracle(_tokenIn, _tokenOut).oracle;
+    if (address(_oracle) == address(0)) revert PairNotSupported(_tokenIn, _tokenOut);
+    return _oracle.quote(_tokenIn, _amountIn, _tokenOut);
+  }
+
+  /// @inheritdoc IPriceOracle
   function addOrModifySupportForPair(address _tokenA, address _tokenB) external {
-    // TODO: Implement
+    (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
+    /* 
+      Only modify if one of the following is true:
+        - There is no current oracle
+        - The current oracle hasn't been forced by an admin
+        - The caller is an admin
+    */
+    bool _shouldModify = !_assignedOracleForPair(__tokenA, __tokenB).forced || hasRole(ADMIN_ROLE, msg.sender);
+    if (_shouldModify) {
+      _addOrModifySupportForPair(__tokenA, __tokenB);
+    }
+  }
+
+  /// @inheritdoc IPriceOracle
+  function addSupportForPairIfNeeded(address _tokenA, address _tokenB) external {
+    if (!isPairAlreadySupported(_tokenA, _tokenB)) {
+      (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
+      _addOrModifySupportForPair(__tokenA, __tokenB);
+    }
   }
 
   /// @inheritdoc IOracleAggregator
-  function assignedOracle(address _tokenA, address _tokenB) external view returns (IPriceOracle) {
+  function assignedOracle(address _tokenA, address _tokenB) public view returns (OracleAssignment memory) {
     (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
-    return _assignedOracle[_keyForPair(__tokenA, __tokenB)];
+    return _assignedOracleForPair(__tokenA, __tokenB);
   }
 
   /// @inheritdoc IOracleAggregator
   function availableOracles() external view returns (IPriceOracle[] memory) {
     return _availableOracles;
+  }
+
+  /// @inheritdoc IOracleAggregator
+  function forceOracle(
+    address _tokenA,
+    address _tokenB,
+    IPriceOracle _oracle
+  ) external onlyRole(ADMIN_ROLE) {
+    (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
+    _setOracle(__tokenA, __tokenB, _oracle, true);
   }
 
   /// @inheritdoc IOracleAggregator
@@ -96,12 +142,27 @@ contract OracleAggregator is AccessControl, IOracleAggregator {
       IPriceOracle _oracle = _availableOracles[i];
       if (_oracle.canSupportPair(_tokenA, _tokenB)) {
         _oracle.addOrModifySupportForPair(_tokenA, _tokenB);
-        _assignedOracle[_keyForPair(_tokenA, _tokenB)] = _oracle;
-        emit OracleAssigned(_tokenA, _tokenB, _oracle);
+        _setOracle(_tokenA, _tokenB, _oracle, false);
         return;
       }
     }
     revert PairNotSupported(_tokenA, _tokenB);
+  }
+
+  /// @dev We expect tokens to be sorted (tokenA < tokenB)
+  function _setOracle(
+    address _tokenA,
+    address _tokenB,
+    IPriceOracle _oracle,
+    bool _forced
+  ) internal {
+    _assignedOracle[_keyForPair(_tokenA, _tokenB)] = OracleAssignment({oracle: _oracle, forced: _forced});
+    emit OracleAssigned(_tokenA, _tokenB, _oracle);
+  }
+
+  /// @dev We expect tokens to be sorted (tokenA < tokenB)
+  function _assignedOracleForPair(address _tokenA, address _tokenB) internal view returns (OracleAssignment memory) {
+    return _assignedOracle[_keyForPair(_tokenA, _tokenB)];
   }
 
   /// @dev We expect tokens to be sorted (tokenA < tokenB)

--- a/solidity/contracts/test/OracleAggregator.sol
+++ b/solidity/contracts/test/OracleAggregator.sol
@@ -16,6 +16,15 @@ contract OracleAggregatorMock is OracleAggregator {
     _addOrModifySupportForPair(_tokenA, _tokenB);
   }
 
+  function setOracle(
+    address _tokenA,
+    address _tokenB,
+    IPriceOracle _oracle,
+    bool _forced
+  ) external {
+    _setOracle(_tokenA, _tokenB, _oracle, _forced);
+  }
+
   function _addOrModifySupportForPair(address _tokenA, address _tokenB) internal override {
     (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
     internalAddOrModifyCalled[__tokenA][__tokenB] = true;

--- a/solidity/interfaces/IOracleAggregator.sol
+++ b/solidity/interfaces/IOracleAggregator.sol
@@ -4,10 +4,20 @@ pragma solidity >=0.5.0;
 import './IPriceOracle.sol';
 
 /**
- * @title An implementation of `IPriceOracle` that aggregates two or more oracles
+ * @title An implementation of `IPriceOracle` that aggregates two or more oracles. It's important to
+ *        note that this oracle is permissioned. Admins can determine available oracles and they can
+ *        also force an oracle for a specific pair
  * @notice This oracle will use two or more oracles to support price quotes
  */
 interface IOracleAggregator is IPriceOracle {
+  /// @notice An oracle's assignment for a specific pair
+  struct OracleAssignment {
+    // The oracle's address
+    IPriceOracle oracle;
+    // Whether the oracle was forced by an admin. If forced, only an admin can modify it
+    bool forced;
+  }
+
   /// @notice Thrown when one of the parameters is a zero address
   error ZeroAddress();
 
@@ -27,17 +37,33 @@ interface IOracleAggregator is IPriceOracle {
 
   /**
    * @notice Returns the assigned oracle (or the zero address if there isn't one) for the given pair
+   * @dev tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
    * @param tokenA One of the pair's tokens
    * @param tokenB The other of the pair's tokens
    * @return The assigned oracle for the given pair
    */
-  function assignedOracle(address tokenA, address tokenB) external view returns (IPriceOracle);
+  function assignedOracle(address tokenA, address tokenB) external view returns (OracleAssignment memory);
 
   /**
    * @notice Returns whether this oracle can support the given pair of tokens
    * @return Whether the given pair of tokens can be supported by the oracle
    */
   function availableOracles() external view returns (IPriceOracle[] memory);
+
+  /**
+   * @notice Sets a new oracle for the given pair. After it's sent, only other admins will be able
+   *         to modify the pair's oracle
+   * @dev Can only be called by users with the admin role
+   *      tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
+   * @param tokenA One of the pair's tokens
+   * @param tokenB The other of the pair's tokens
+   * @param oracle The oracle to set
+   */
+  function forceOracle(
+    address tokenA,
+    address tokenB,
+    IPriceOracle oracle
+  ) external;
 
   /**
    * @notice Sets a new list of oracles to be used by the aggregator

--- a/solidity/interfaces/IPriceOracle.sol
+++ b/solidity/interfaces/IPriceOracle.sol
@@ -19,17 +19,28 @@ interface IPriceOracle {
   function canSupportPair(address tokenA, address tokenB) external view returns (bool);
 
   /**
+   * @notice Returns whether this oracle is already supporting the given pair of tokens
+   * @dev tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
+   * @param tokenA One of the pair's tokens
+   * @param tokenB The other of the pair's tokens
+   * @return Whether the given pair of tokens is already being supported by the oracle
+   */
+  function isPairAlreadySupported(address tokenA, address tokenB) external view returns (bool);
+
+  /**
    * @notice Returns a quote, based on the given tokens and amount
+   * @dev Will revert if pair cannot be supported
    * @param tokenIn The token that will be provided
    * @param amountIn The amount that will be provided
    * @param tokenOut The token we would like to quote
    * @return amountOut How much `tokenOut` will be returned in exchange for `amountIn` amount of `tokenIn`
    */
-  // function quote(
-  //   address tokenIn,
-  //   uint256 amountIn,
-  //   address tokenOut
-  // ) external view returns (uint256 amountOut);
+  function quote(
+    address tokenIn,
+    uint256 amountIn,
+    address tokenOut
+  ) external view returns (uint256 amountOut);
+
   /**
    * @notice Add or reconfigures the support for a given pair. This function will let the oracle take some actions
    *         to configure the pair, in preparation for future quotes. Can be called many times in order to let the oracle
@@ -48,5 +59,5 @@ interface IPriceOracle {
    * @param tokenA One of the pair's tokens
    * @param tokenB The other of the pair's tokens
    */
-  // function addSupportForPairIfNeeded(address tokenA, address tokenB) external;
+  function addSupportForPairIfNeeded(address tokenA, address tokenB) external;
 }

--- a/test/e2e/oracle-aggregator.spec.ts
+++ b/test/e2e/oracle-aggregator.spec.ts
@@ -1,0 +1,56 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { given, then, when } from '@utils/bdd';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { OracleAggregatorMock, OracleAggregatorMock__factory, IPriceOracle } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { smock, FakeContract } from '@defi-wonderland/smock';
+
+chai.use(smock.matchers);
+
+describe('OracleAggregator', () => {
+  const TOKEN_A = '0x0000000000000000000000000000000000000001';
+  const TOKEN_B = '0x0000000000000000000000000000000000000002';
+  let superAdmin: SignerWithAddress, admin: SignerWithAddress;
+  let oracleAggregator: OracleAggregatorMock;
+  let superAdminRole: string, adminRole: string;
+  let oracle1: FakeContract<IPriceOracle>, oracle2: FakeContract<IPriceOracle>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [, superAdmin, admin] = await ethers.getSigners();
+    const oracleAggregatorFactory: OracleAggregatorMock__factory = await ethers.getContractFactory(
+      'solidity/contracts/OracleAggregator.sol:OracleAggregator'
+    );
+    oracle1 = await smock.fake('IPriceOracle');
+    oracle2 = await smock.fake('IPriceOracle');
+    oracleAggregator = await oracleAggregatorFactory.deploy([oracle1.address, oracle2.address], superAdmin.address, [admin.address]);
+    superAdminRole = await oracleAggregator.SUPER_ADMIN_ROLE();
+    adminRole = await oracleAggregator.ADMIN_ROLE();
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach('Deploy and configure', async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('force and update', () => {
+    when('an oracle is forced', () => {
+      given(async () => {
+        oracle1.canSupportPair.returns(true);
+        oracle2.canSupportPair.returns(true);
+        await oracleAggregator.connect(admin).forceOracle(TOKEN_A, TOKEN_B, oracle2.address);
+      });
+      describe('and then an admin updates the support', () => {
+        given(async () => {
+          await oracleAggregator.connect(admin).addOrModifySupportForPair(TOKEN_A, TOKEN_B);
+        });
+        then('a oracle that takes precedence will be assigned', async () => {
+          const { oracle, forced } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
+          expect(oracle).to.equal(oracle1.address);
+          expect(forced).to.be.false;
+        });
+      });
+    });
+  });
+});

--- a/test/unit/oracle-aggregator.spec.ts
+++ b/test/unit/oracle-aggregator.spec.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { constants } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 import { behaviours } from '@utils';
 import { given, then, when } from '@utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
@@ -108,22 +108,199 @@ describe('OracleAggregator', () => {
     });
   });
 
+  describe('isPairAlreadySupported', () => {
+    when('no oracle has been assigned', () => {
+      then('pair is not already supported', async () => {
+        expect(await oracleAggregator.isPairAlreadySupported(TOKEN_A, TOKEN_B)).to.be.false;
+      });
+    });
+    when('oracle has been assigned and it still supports the pair', () => {
+      given(async () => {
+        oracle1.isPairAlreadySupported.returns(true);
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, false);
+      });
+      then('pair is already supported', async () => {
+        expect(await oracleAggregator.isPairAlreadySupported(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+    when('oracle has been assigned but it does not support the pair', () => {
+      given(async () => {
+        oracle1.isPairAlreadySupported.returns(false);
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, false);
+      });
+      then('pair is not already supported', async () => {
+        expect(await oracleAggregator.isPairAlreadySupported(TOKEN_A, TOKEN_B)).to.be.false;
+      });
+    });
+  });
+
+  describe('quote', () => {
+    when('no oracle is being used for the pair', () => {
+      then('tx is reverted with reason', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: oracleAggregator,
+          func: 'quote',
+          args: [TOKEN_A, 1000, TOKEN_B],
+          message: `PairNotSupported`,
+        });
+      });
+    });
+    when('oracle is being used for pair', () => {
+      const RESULT = BigNumber.from(5);
+      let amountOut: BigNumber;
+      given(async () => {
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, false);
+        oracle1.quote.returns(RESULT);
+        amountOut = await oracleAggregator.quote(TOKEN_A, 1000, TOKEN_B);
+      });
+      then('oracle was called', async () => {
+        expect(oracle1.quote).to.have.been.calledWith(TOKEN_A, 1000, TOKEN_B);
+      });
+      then('result is what the oracle returned', () => {
+        expect(amountOut).to.equal(RESULT);
+      });
+    });
+  });
+
+  describe('addOrModifySupportForPair', () => {
+    when(`pair's addreses are inverted`, () => {
+      given(async () => {
+        await oracleAggregator.addOrModifySupportForPair(TOKEN_B, TOKEN_A);
+      });
+      then(`correct order is sent to internal add support`, async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+    when('no oracle has been assigned', () => {
+      given(async () => {
+        await oracleAggregator.addOrModifySupportForPair(TOKEN_A, TOKEN_B);
+      });
+      then('pair is modified', async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+    when(`oracle is assigned but it hasn't been forced`, () => {
+      given(async () => {
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, false);
+        await oracleAggregator.addOrModifySupportForPair(TOKEN_A, TOKEN_B);
+      });
+      then('pair is modified', async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+    when(`oracle was forced but caller is admin`, () => {
+      given(async () => {
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, true);
+        await oracleAggregator.connect(admin).addOrModifySupportForPair(TOKEN_A, TOKEN_B);
+      });
+      then('pair is modified', async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+    when(`oracle was forced and caller is not admin`, () => {
+      given(async () => {
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, true);
+        await oracleAggregator.addOrModifySupportForPair(TOKEN_A, TOKEN_B);
+      });
+      then('pair is not modified', async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.false;
+      });
+    });
+  });
+
+  describe('addSupportForPairIfNeeded', () => {
+    when(`pair's addreses are inverted`, () => {
+      given(async () => {
+        await oracleAggregator.addSupportForPairIfNeeded(TOKEN_B, TOKEN_A);
+      });
+      then(`correct order is sent to internal add support`, async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+    when('pair does not have an assigned oracle', () => {
+      given(async () => {
+        await oracleAggregator.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B);
+      });
+      then('internal add support is called', async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+    when('pair already has an assigned oracle and it still supports the pair', () => {
+      given(async () => {
+        oracle1.isPairAlreadySupported.returns(true);
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, true);
+        await oracleAggregator.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B);
+      });
+      then('internal add is not called', async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.false;
+      });
+    });
+    when('pair already has an assigned oracle but it does not support the pair anymore', () => {
+      given(async () => {
+        oracle1.isPairAlreadySupported.returns(false);
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, true);
+        await oracleAggregator.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B);
+      });
+      then('internal add support is called', async () => {
+        expect(await oracleAggregator.internalAddOrModifyCalled(TOKEN_A, TOKEN_B)).to.be.true;
+      });
+    });
+  });
+
   describe('assignedOracle', () => {
     given(async () => {
       oracle1.canSupportPair.returns(true);
-      await oracleAggregator.internalAddOrModifySupportForPair(TOKEN_A, TOKEN_B);
+      await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, false);
     });
     when(`pair's addreses are inverted`, () => {
       then(`oracle is still returned`, async () => {
-        const oracle = await oracleAggregator.assignedOracle(TOKEN_B, TOKEN_A);
+        const { oracle } = await oracleAggregator.assignedOracle(TOKEN_B, TOKEN_A);
         expect(oracle).to.equal(oracle1.address);
       });
     });
     when('addresses are sent sorted', () => {
       then(`oracle is still returned`, async () => {
-        const oracle = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
+        const { oracle } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
         expect(oracle).to.equal(oracle1.address);
       });
+    });
+  });
+
+  describe('forceOracle', () => {
+    when(`oracle is forced and pair's addreses are inverted`, () => {
+      let tx: TransactionResponse;
+      given(async () => {
+        tx = await oracleAggregator.connect(admin).forceOracle(TOKEN_B, TOKEN_A, oracle1.address);
+      });
+      then(`oracle is assigned correctly`, async () => {
+        const { oracle, forced } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
+        expect(oracle).to.equal(oracle1.address);
+        expect(forced).to.be.true;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(oracleAggregator, 'OracleAssigned').withArgs(TOKEN_A, TOKEN_B, oracle1.address);
+      });
+    });
+    when('oracle is forced', () => {
+      let tx: TransactionResponse;
+      given(async () => {
+        tx = await oracleAggregator.connect(admin).forceOracle(TOKEN_A, TOKEN_B, oracle2.address);
+      });
+      then(`oracle is assigned correctly`, async () => {
+        const { oracle, forced } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
+        expect(oracle).to.equal(oracle2.address);
+        expect(forced).to.be.true;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(oracleAggregator, 'OracleAssigned').withArgs(TOKEN_A, TOKEN_B, oracle2.address);
+      });
+    });
+    shouldBeExecutableOnlyByRole({
+      contract: () => oracleAggregator,
+      funcAndSignature: 'forceOracle',
+      params: [TOKEN_A, TOKEN_B, TOKEN_A],
+      addressWithRole: () => admin,
+      role: () => adminRole,
     });
   });
 
@@ -141,7 +318,9 @@ describe('OracleAggregator', () => {
         expect(oracle2.addOrModifySupportForPair).to.not.have.been.called;
       });
       then('now oracle 1 will be used', async () => {
-        expect(await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B)).to.equal(oracle1.address);
+        const { oracle, forced } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
+        expect(oracle).to.equal(oracle1.address);
+        expect(forced).to.be.false;
       });
       then('event is emitted', async () => {
         await expect(tx).to.emit(oracleAggregator, 'OracleAssigned').withArgs(TOKEN_A, TOKEN_B, oracle1.address);
@@ -161,7 +340,9 @@ describe('OracleAggregator', () => {
         expect(oracle1.addOrModifySupportForPair).to.not.have.been.called;
       });
       then('now oracle 2 will be used', async () => {
-        expect(await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B)).to.equal(oracle2.address);
+        const { oracle, forced } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
+        expect(oracle).to.equal(oracle2.address);
+        expect(forced).to.be.false;
       });
       then('event is emitted', async () => {
         await expect(tx).to.emit(oracleAggregator, 'OracleAssigned').withArgs(TOKEN_A, TOKEN_B, oracle2.address);
@@ -189,28 +370,32 @@ describe('OracleAggregator', () => {
     const NEW_ORACLE_3 = '0x0000000000000000000000000000000000000003';
     setOraclesTest({
       when: 'the number of oracles stay the same',
-      newOracles: [NEW_ORACLE_1, NEW_ORACLE_2],
+      newOracles: () => [NEW_ORACLE_1, NEW_ORACLE_2],
     });
     setOraclesTest({
       when: 'the number of oracles increased',
-      newOracles: [NEW_ORACLE_1, NEW_ORACLE_2, NEW_ORACLE_3],
+      newOracles: () => [NEW_ORACLE_1, NEW_ORACLE_2, NEW_ORACLE_3],
     });
     setOraclesTest({
       when: 'the number of oracles is reduced',
-      newOracles: [NEW_ORACLE_1],
+      newOracles: () => [NEW_ORACLE_1],
     });
-    function setOraclesTest({ when: title, newOracles }: { when: string; newOracles: string[] }) {
+    setOraclesTest({
+      when: 'changing order of current added oracles',
+      newOracles: () => [oracle2.address, oracle1.address],
+    });
+    function setOraclesTest({ when: title, newOracles }: { when: string; newOracles: () => string[] }) {
       when(title, () => {
         let tx: TransactionResponse;
         given(async () => {
-          tx = await oracleAggregator.connect(admin).setAvailableOracles(newOracles);
+          tx = await oracleAggregator.connect(admin).setAvailableOracles(newOracles());
         });
         then('oracles are set correctly', async () => {
           const available = await oracleAggregator.availableOracles();
-          expect(available).to.eql(newOracles);
+          expect(available).to.eql(newOracles());
         });
         then('event is emitted', async () => {
-          await expect(tx).to.emit(oracleAggregator, 'OracleListUpdated').withArgs(newOracles);
+          await expect(tx).to.emit(oracleAggregator, 'OracleListUpdated').withArgs(newOracles());
         });
       });
     }


### PR DESCRIPTION
We are now adding `_addOrModifySupportForPair`. This function will go over each oracle and assign the first one that supports the given pair