### PR TITLE
feat: implement add support if needed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,34 +35,34 @@ jobs:
         run: yarn test:unit
         env:
           TS_NODE_SKIP_IGNORE: true
-  # e2e:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out github repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 1
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out github repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
-  #     - name: Cache node modules
-  #       uses: actions/cache@v2
-  #       env:
-  #         cache-name: cache-node-modules
-  #       with:
-  #         path: "**/node_modules"
-  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: "16.x"
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
 
-  #     - name: Install dependencies
-  #       run: yarn --frozen-lockfile
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
 
-  #     - name: Run e2e tests
-  #       run: yarn test:e2e
-  #       env:
-  #         TS_NODE_SKIP_IGNORE: true
+      - name: Run e2e tests
+        run: yarn test:e2e
+        env:
+          TS_NODE_SKIP_IGNORE: true
   # integration:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/solidity/contracts/OracleAggregator.sol
+++ b/solidity/contracts/OracleAggregator.sol
@@ -45,6 +45,24 @@ contract OracleAggregator is AccessControl, IOracleAggregator {
   }
 
   /// @inheritdoc IPriceOracle
+  function isPairAlreadySupported(address _tokenA, address _tokenB) public view returns (bool) {
+    IPriceOracle _oracle = assignedOracle(_tokenA, _tokenB).oracle;
+    // We check if the oracle still supports the pair, since it might have lost support
+    return address(_oracle) != address(0) && _oracle.isPairAlreadySupported(_tokenA, _tokenA);
+  }
+
+  /// @inheritdoc IPriceOracle
+  function quote(
+    address _tokenIn,
+    uint256 _amountIn,
+    address _tokenOut
+  ) external view returns (uint256 _amountOut) {
+    IPriceOracle _oracle = assignedOracle(_tokenIn, _tokenOut).oracle;
+    if (address(_oracle) == address(0)) revert PairNotSupported(_tokenIn, _tokenOut);
+    return _oracle.quote(_tokenIn, _amountIn, _tokenOut);
+  }
+
+  /// @inheritdoc IPriceOracle
   function addOrModifySupportForPair(address _tokenA, address _tokenB) external {
     (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
     /* 
@@ -61,15 +79,14 @@ contract OracleAggregator is AccessControl, IOracleAggregator {
 
   /// @inheritdoc IPriceOracle
   function addSupportForPairIfNeeded(address _tokenA, address _tokenB) external {
-    (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
-    IPriceOracle _assigned = _assignedOracleForPair(__tokenA, __tokenB).oracle;
-    if (address(_assigned) == address(0)) {
+    if (!isPairAlreadySupported(_tokenA, _tokenB)) {
+      (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
       _addOrModifySupportForPair(__tokenA, __tokenB);
     }
   }
 
   /// @inheritdoc IOracleAggregator
-  function assignedOracle(address _tokenA, address _tokenB) external view returns (OracleAssignment memory) {
+  function assignedOracle(address _tokenA, address _tokenB) public view returns (OracleAssignment memory) {
     (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
     return _assignedOracleForPair(__tokenA, __tokenB);
   }

--- a/solidity/interfaces/IPriceOracle.sol
+++ b/solidity/interfaces/IPriceOracle.sol
@@ -19,17 +19,28 @@ interface IPriceOracle {
   function canSupportPair(address tokenA, address tokenB) external view returns (bool);
 
   /**
+   * @notice Returns whether this oracle is already supporting the given pair of tokens
+   * @dev tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
+   * @param tokenA One of the pair's tokens
+   * @param tokenB The other of the pair's tokens
+   * @return Whether the given pair of tokens is already being supported by the oracle
+   */
+  function isPairAlreadySupported(address tokenA, address tokenB) external view returns (bool);
+
+  /**
    * @notice Returns a quote, based on the given tokens and amount
+   * @dev Will revert if pair cannot be supported
    * @param tokenIn The token that will be provided
    * @param amountIn The amount that will be provided
    * @param tokenOut The token we would like to quote
    * @return amountOut How much `tokenOut` will be returned in exchange for `amountIn` amount of `tokenIn`
    */
-  // function quote(
-  //   address tokenIn,
-  //   uint256 amountIn,
-  //   address tokenOut
-  // ) external view returns (uint256 amountOut);
+  function quote(
+    address tokenIn,
+    uint256 amountIn,
+    address tokenOut
+  ) external view returns (uint256 amountOut);
+
   /**
    * @notice Add or reconfigures the support for a given pair. This function will let the oracle take some actions
    *         to configure the pair, in preparation for future quotes. Can be called many times in order to let the oracle

--- a/test/e2e/oracle-aggregator.spec.ts
+++ b/test/e2e/oracle-aggregator.spec.ts
@@ -1,0 +1,56 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { given, then, when } from '@utils/bdd';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { OracleAggregatorMock, OracleAggregatorMock__factory, IPriceOracle } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { smock, FakeContract } from '@defi-wonderland/smock';
+
+chai.use(smock.matchers);
+
+describe('OracleAggregator', () => {
+  const TOKEN_A = '0x0000000000000000000000000000000000000001';
+  const TOKEN_B = '0x0000000000000000000000000000000000000002';
+  let superAdmin: SignerWithAddress, admin: SignerWithAddress;
+  let oracleAggregator: OracleAggregatorMock;
+  let superAdminRole: string, adminRole: string;
+  let oracle1: FakeContract<IPriceOracle>, oracle2: FakeContract<IPriceOracle>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [, superAdmin, admin] = await ethers.getSigners();
+    const oracleAggregatorFactory: OracleAggregatorMock__factory = await ethers.getContractFactory(
+      'solidity/contracts/OracleAggregator.sol:OracleAggregator'
+    );
+    oracle1 = await smock.fake('IPriceOracle');
+    oracle2 = await smock.fake('IPriceOracle');
+    oracleAggregator = await oracleAggregatorFactory.deploy([oracle1.address, oracle2.address], superAdmin.address, [admin.address]);
+    superAdminRole = await oracleAggregator.SUPER_ADMIN_ROLE();
+    adminRole = await oracleAggregator.ADMIN_ROLE();
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach('Deploy and configure', async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('force and update', () => {
+    when('an oracle is forced', () => {
+      given(async () => {
+        oracle1.canSupportPair.returns(true);
+        oracle2.canSupportPair.returns(true);
+        await oracleAggregator.connect(admin).forceOracle(TOKEN_A, TOKEN_B, oracle2.address);
+      });
+      describe('and then an admin updates the support', () => {
+        given(async () => {
+          await oracleAggregator.connect(admin).addOrModifySupportForPair(TOKEN_A, TOKEN_B);
+        });
+        then('a oracle that takes precedence will be assigned', async () => {
+          const { oracle, forced } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
+          expect(oracle).to.equal(oracle1.address);
+          expect(forced).to.be.false;
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
We are now implementing `addSupportForPairIfNeeded`. This function will only add support for a pair if no support has been added already