### PR TITLE
feat: add is pair already supported

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,34 +35,34 @@ jobs:
         run: yarn test:unit
         env:
           TS_NODE_SKIP_IGNORE: true
-  # e2e:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out github repository
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 1
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out github repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
-  #     - name: Cache node modules
-  #       uses: actions/cache@v2
-  #       env:
-  #         cache-name: cache-node-modules
-  #       with:
-  #         path: "**/node_modules"
-  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
-  #     - name: Install node
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: "16.x"
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
 
-  #     - name: Install dependencies
-  #       run: yarn --frozen-lockfile
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
 
-  #     - name: Run e2e tests
-  #       run: yarn test:e2e
-  #       env:
-  #         TS_NODE_SKIP_IGNORE: true
+      - name: Run e2e tests
+        run: yarn test:e2e
+        env:
+          TS_NODE_SKIP_IGNORE: true
   # integration:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/solidity/contracts/OracleAggregator.sol
+++ b/solidity/contracts/OracleAggregator.sol
@@ -52,6 +52,17 @@ contract OracleAggregator is AccessControl, IOracleAggregator {
   }
 
   /// @inheritdoc IPriceOracle
+  function quote(
+    address _tokenIn,
+    uint256 _amountIn,
+    address _tokenOut
+  ) external view returns (uint256 _amountOut) {
+    IPriceOracle _oracle = assignedOracle(_tokenIn, _tokenOut).oracle;
+    if (address(_oracle) == address(0)) revert PairNotSupported(_tokenIn, _tokenOut);
+    return _oracle.quote(_tokenIn, _amountIn, _tokenOut);
+  }
+
+  /// @inheritdoc IPriceOracle
   function addOrModifySupportForPair(address _tokenA, address _tokenB) external {
     (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
     /* 

--- a/solidity/interfaces/IPriceOracle.sol
+++ b/solidity/interfaces/IPriceOracle.sol
@@ -29,16 +29,18 @@ interface IPriceOracle {
 
   /**
    * @notice Returns a quote, based on the given tokens and amount
+   * @dev Will revert if pair cannot be supported
    * @param tokenIn The token that will be provided
    * @param amountIn The amount that will be provided
    * @param tokenOut The token we would like to quote
    * @return amountOut How much `tokenOut` will be returned in exchange for `amountIn` amount of `tokenIn`
    */
-  // function quote(
-  //   address tokenIn,
-  //   uint256 amountIn,
-  //   address tokenOut
-  // ) external view returns (uint256 amountOut);
+  function quote(
+    address tokenIn,
+    uint256 amountIn,
+    address tokenOut
+  ) external view returns (uint256 amountOut);
+
   /**
    * @notice Add or reconfigures the support for a given pair. This function will let the oracle take some actions
    *         to configure the pair, in preparation for future quotes. Can be called many times in order to let the oracle

--- a/test/e2e/oracle-aggregator.spec.ts
+++ b/test/e2e/oracle-aggregator.spec.ts
@@ -1,0 +1,56 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { given, then, when } from '@utils/bdd';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { OracleAggregatorMock, OracleAggregatorMock__factory, IPriceOracle } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { smock, FakeContract } from '@defi-wonderland/smock';
+
+chai.use(smock.matchers);
+
+describe('OracleAggregator', () => {
+  const TOKEN_A = '0x0000000000000000000000000000000000000001';
+  const TOKEN_B = '0x0000000000000000000000000000000000000002';
+  let superAdmin: SignerWithAddress, admin: SignerWithAddress;
+  let oracleAggregator: OracleAggregatorMock;
+  let superAdminRole: string, adminRole: string;
+  let oracle1: FakeContract<IPriceOracle>, oracle2: FakeContract<IPriceOracle>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [, superAdmin, admin] = await ethers.getSigners();
+    const oracleAggregatorFactory: OracleAggregatorMock__factory = await ethers.getContractFactory(
+      'solidity/contracts/OracleAggregator.sol:OracleAggregator'
+    );
+    oracle1 = await smock.fake('IPriceOracle');
+    oracle2 = await smock.fake('IPriceOracle');
+    oracleAggregator = await oracleAggregatorFactory.deploy([oracle1.address, oracle2.address], superAdmin.address, [admin.address]);
+    superAdminRole = await oracleAggregator.SUPER_ADMIN_ROLE();
+    adminRole = await oracleAggregator.ADMIN_ROLE();
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach('Deploy and configure', async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('force and update', () => {
+    when('an oracle is forced', () => {
+      given(async () => {
+        oracle1.canSupportPair.returns(true);
+        oracle2.canSupportPair.returns(true);
+        await oracleAggregator.connect(admin).forceOracle(TOKEN_A, TOKEN_B, oracle2.address);
+      });
+      describe('and then an admin updates the support', () => {
+        given(async () => {
+          await oracleAggregator.connect(admin).addOrModifySupportForPair(TOKEN_A, TOKEN_B);
+        });
+        then('a oracle that takes precedence will be assigned', async () => {
+          const { oracle, forced } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
+          expect(oracle).to.equal(oracle1.address);
+          expect(forced).to.be.false;
+        });
+      });
+    });
+  });
+});

--- a/test/unit/oracle-aggregator.spec.ts
+++ b/test/unit/oracle-aggregator.spec.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { constants } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 import { behaviours } from '@utils';
 import { given, then, when } from '@utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
@@ -130,6 +130,34 @@ describe('OracleAggregator', () => {
       });
       then('pair is not already supported', async () => {
         expect(await oracleAggregator.isPairAlreadySupported(TOKEN_A, TOKEN_B)).to.be.false;
+      });
+    });
+  });
+
+  describe('quote', () => {
+    when('no oracle is being used for the pair', () => {
+      then('tx is reverted with reason', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: oracleAggregator,
+          func: 'quote',
+          args: [TOKEN_A, 1000, TOKEN_B],
+          message: `PairNotSupported`,
+        });
+      });
+    });
+    when('oracle is being used for pair', () => {
+      const RESULT = BigNumber.from(5);
+      let amountOut: BigNumber;
+      given(async () => {
+        await oracleAggregator.setOracle(TOKEN_A, TOKEN_B, oracle1.address, false);
+        oracle1.quote.returns(RESULT);
+        amountOut = await oracleAggregator.quote(TOKEN_A, 1000, TOKEN_B);
+      });
+      then('oracle was called', async () => {
+        expect(oracle1.quote).to.have.been.calledWith(TOKEN_A, 1000, TOKEN_B);
+      });
+      then('result is what the oracle returned', () => {
+        expect(amountOut).to.equal(RESULT);
       });
     });
   });
@@ -342,28 +370,32 @@ describe('OracleAggregator', () => {
     const NEW_ORACLE_3 = '0x0000000000000000000000000000000000000003';
     setOraclesTest({
       when: 'the number of oracles stay the same',
-      newOracles: [NEW_ORACLE_1, NEW_ORACLE_2],
+      newOracles: () => [NEW_ORACLE_1, NEW_ORACLE_2],
     });
     setOraclesTest({
       when: 'the number of oracles increased',
-      newOracles: [NEW_ORACLE_1, NEW_ORACLE_2, NEW_ORACLE_3],
+      newOracles: () => [NEW_ORACLE_1, NEW_ORACLE_2, NEW_ORACLE_3],
     });
     setOraclesTest({
       when: 'the number of oracles is reduced',
-      newOracles: [NEW_ORACLE_1],
+      newOracles: () => [NEW_ORACLE_1],
     });
-    function setOraclesTest({ when: title, newOracles }: { when: string; newOracles: string[] }) {
+    setOraclesTest({
+      when: 'changing order of current added oracles',
+      newOracles: () => [oracle2.address, oracle1.address],
+    });
+    function setOraclesTest({ when: title, newOracles }: { when: string; newOracles: () => string[] }) {
       when(title, () => {
         let tx: TransactionResponse;
         given(async () => {
-          tx = await oracleAggregator.connect(admin).setAvailableOracles(newOracles);
+          tx = await oracleAggregator.connect(admin).setAvailableOracles(newOracles());
         });
         then('oracles are set correctly', async () => {
           const available = await oracleAggregator.availableOracles();
-          expect(available).to.eql(newOracles);
+          expect(available).to.eql(newOracles());
         });
         then('event is emitted', async () => {
-          await expect(tx).to.emit(oracleAggregator, 'OracleListUpdated').withArgs(newOracles);
+          await expect(tx).to.emit(oracleAggregator, 'OracleListUpdated').withArgs(newOracles());
         });
       });
     }


### PR DESCRIPTION
We are now adding `isPairAlreadySupported`. This function will return if the oracle already supports the given pair or not

Also, we realized that there was a scenario where the aggregator might have an oracle assigned, but it then lost support for the pair. In that scenario, `addSupportForPairIfNeeded` will add support again