### PR TITLE
feat: add set cardinality

### DIFF
--- a/solidity/contracts/adapters/UniswapV3Adapter.sol
+++ b/solidity/contracts/adapters/UniswapV3Adapter.sol
@@ -16,8 +16,8 @@ contract UniswapV3Adapter is AccessControl, IUniswapV3Adapter {
   uint16 public immutable MIN_PERIOD;
   /// @inheritdoc IUniswapV3Adapter
   uint16 public period;
-
-  // uint8 public cardinalityPerMinute;
+  /// @inheritdoc IUniswapV3Adapter
+  uint8 public cardinalityPerMinute;
 
   constructor(InitialConfig memory _initialConfig) {
     if (_initialConfig.superAdmin == address(0)) revert ZeroAddress();
@@ -35,6 +35,11 @@ contract UniswapV3Adapter is AccessControl, IUniswapV3Adapter {
       revert InvalidPeriod(_initialConfig.initialPeriod);
     period = _initialConfig.initialPeriod;
     emit PeriodChanged(_initialConfig.initialPeriod);
+
+    // Set cardinality, by using the oracle's default
+    uint8 _cardinality = UNISWAP_V3_ORACLE.CARDINALITY_PER_MINUTE();
+    cardinalityPerMinute = _cardinality;
+    emit CardinalityPerMinuteChanged(_cardinality);
   }
 
   /// @inheritdoc IUniswapV3Adapter
@@ -42,5 +47,12 @@ contract UniswapV3Adapter is AccessControl, IUniswapV3Adapter {
     if (_newPeriod < MIN_PERIOD || _newPeriod > MAX_PERIOD) revert InvalidPeriod(_newPeriod);
     period = _newPeriod;
     emit PeriodChanged(_newPeriod);
+  }
+
+  /// @inheritdoc IUniswapV3Adapter
+  function setCardinalityPerMinute(uint8 _cardinalityPerMinute) external onlyRole(ADMIN_ROLE) {
+    if (_cardinalityPerMinute == 0) revert InvalidCardinalityPerMinute();
+    cardinalityPerMinute = _cardinalityPerMinute;
+    emit CardinalityPerMinuteChanged(_cardinalityPerMinute);
   }
 }

--- a/solidity/interfaces/adapters/IUniswapV3Adapter.sol
+++ b/solidity/interfaces/adapters/IUniswapV3Adapter.sol
@@ -20,11 +20,20 @@ interface IUniswapV3Adapter {
    */
   event PeriodChanged(uint32 period);
 
+  /**
+   * @notice Emitted when a new cardinality per minute is set
+   * @param cardinalityPerMinute The new cardinality per minute
+   */
+  event CardinalityPerMinuteChanged(uint8 cardinalityPerMinute);
+
   /// @notice Thrown when one of the parameters is the zero address
   error ZeroAddress();
 
   /// @notice Thrown when trying to set an invalid period
   error InvalidPeriod(uint16 period);
+
+  /// @notice Thrown when trying to set an invalid cardinality
+  error InvalidCardinalityPerMinute();
 
   /**
    * @notice Returns the address of the Uniswap oracle
@@ -54,10 +63,23 @@ interface IUniswapV3Adapter {
   function period() external view returns (uint16);
 
   /**
+   * @notice Returns the cardinality per minute used for adding support to pairs
+   * @return The cardinality per minute used for increase cardinality calculations
+   */
+  function cardinalityPerMinute() external view returns (uint8);
+
+  /**
    * @notice Sets the period to be used for the TWAP calculation
    * @dev Will revert it is lower than the minimum period or greater than maximum period
    *      WARNING: increasing the period could cause big problems, because Uniswap V3 pools might not support a TWAP so old
    * @param newPeriod The new period
    */
   function setPeriod(uint16 newPeriod) external;
+
+  /**
+   * @notice Sets the cardinality per minute to be used when increasing observation cardinality at the moment of adding support for pairs
+   * @dev WARNING: increasing the cardinality per minute will make adding support to a pair significantly costly
+   * @param cardinalityPerMinute The new cardinality per minute
+   */
+  function setCardinalityPerMinute(uint8 cardinalityPerMinute) external;
 }


### PR DESCRIPTION
We are now adding `setCardinalityPerMinute`. The idea is to make this configurable so that we can modify if we need to. Since the oracle's value cannot be modified, we are doing this as backup